### PR TITLE
Remove `charcodes` from dependencies.

### DIFF
--- a/packages/babel-plugin-transform-charcodes/package.json
+++ b/packages/babel-plugin-transform-charcodes/package.json
@@ -31,6 +31,7 @@
     "@babel/register": "^7.0.0-beta.31",
     "@babel/types": "^7.0.0-beta.31",
     "chai": "^4.1.2",
+    "charcodes": "^0.0.9",
     "mocha": "^4.0.1"
   },
   "babel": {
@@ -41,8 +42,7 @@
   },
   "dependencies": {
     "@babel/traverse": "^7.0.0-beta.31",
-    "babylon": "^7.0.0-beta.31",
-    "charcodes": "^0.0.9"
+    "babylon": "^7.0.0-beta.31"
   },
   "peerDependencies": {
     "charcodes": "^0.0.9"


### PR DESCRIPTION
It was already defined in `peerDependencies`, so it was not needed in `depenencies`.
I left it in `devDependencies` since it is needed in tests.

Follow up to https://github.com/xtuc/charcodes/commit/0cbd93b33e196ddf17b224c6f51d44abe6f203be